### PR TITLE
Fix hashing

### DIFF
--- a/library/src/main/java/com/okta/appauth/android/OAuthClientConfiguration.java
+++ b/library/src/main/java/com/okta/appauth/android/OAuthClientConfiguration.java
@@ -193,7 +193,7 @@ public class OAuthClientConfiguration {
             throws InvalidJsonDocumentException {
         JsonParser jsonParser = JsonParser.forJson(jsonObject);
 
-        mConfigHash = jsonObject.hashCode();
+        mConfigHash = jsonObject.toString().hashCode();
 
         mClientId = jsonParser.getRequiredString("client_id");
         mRedirectUri = jsonParser.getRequiredUri("redirect_uri");


### PR DESCRIPTION
The hashing is a good idea, but the current code hashes *the object* and not *its contents*. Issues arise when readConfiguration is given a totally new and different object that nonetheless contains the exact same string, for example.

Took me a bit to find that one.