### PR TITLE
Accept valid config only

### DIFF
--- a/library/src/main/java/com/okta/appauth/android/OktaAppAuth.java
+++ b/library/src/main/java/com/okta/appauth/android/OktaAppAuth.java
@@ -595,8 +595,8 @@ public class OktaAppAuth {
                 Log.e(TAG, "Configuration was invalid: " + mConfiguration.getConfigurationError());
                 listener.onTokenFailure(
                         AuthorizationException.GeneralErrors.INVALID_DISCOVERY_DOCUMENT);
+                return;
             }
-
             mConfiguration.acceptConfiguration();
         }
 


### PR DESCRIPTION
Configuration is accepted even if it is invalid. If it is invalid this will not be detected on second run of the app.